### PR TITLE
converted cidr_blocks to list

### DIFF
--- a/sg_cassandra/main.tf
+++ b/sg_cassandra/main.tf
@@ -25,7 +25,7 @@ resource "aws_security_group_rule" "ingress_tcp_9042_self" {
   from_port         = 9042
   to_port           = 9042
   protocol          = "tcp"
-  cidr_blocks       = "${var.source_cidr_block}"
+  cidr_blocks       = ["${var.source_cidr_block}"]
   type              = "ingress"
 }
 
@@ -35,7 +35,7 @@ resource "aws_security_group_rule" "ingress_tcp_9160_self" {
   from_port         = 9160
   to_port           = 9160
   protocol          = "tcp"
-  cidr_blocks       = "${var.source_cidr_block}"
+  cidr_blocks       = ["${var.source_cidr_block}"]
   type              = "ingress"
 }
 
@@ -45,6 +45,6 @@ resource "aws_security_group_rule" "ingress_tcp_7199_self" {
   from_port         = 7199
   to_port           = 7199
   protocol          = "tcp"
-  cidr_blocks       = "${var.source_cidr_block}"
+  cidr_blocks       = ["${var.source_cidr_block}"]
   type              = "ingress"
 }


### PR DESCRIPTION
`terraform plan` failed with the following ```3 error(s) occurred:

* module.cassandra.module.cassandra_security_group.aws_security_group_rule.ingress_tcp_7199_self: cidr_blocks: should be a list
* module.cassandra.module.cassandra_security_group.aws_security_group_rule.ingress_tcp_9042_self: cidr_blocks: should be a list
* module.cassandra.module.cassandra_security_group.aws_security_group_rule.ingress_tcp_9160_self: cidr_blocks: should be a list```. Proposing conversion of `cidr_blocks` properties to list.